### PR TITLE
Added ability to show Note in Inspector

### DIFF
--- a/Assets/EdNotes/Scripts/Editor/EditorNotes.cs
+++ b/Assets/EdNotes/Scripts/Editor/EditorNotes.cs
@@ -29,7 +29,7 @@ namespace EdNotes
 
 		public static NotesContainer GetContainer(Scene scene)
 		{
-			if (cache == null)
+			if (cache == null || !cache.ContainsKey(scene))
 			{
 				cache = new Dictionary<Scene, NotesContainer>();
 				UpdateSceneCache();
@@ -56,6 +56,7 @@ namespace EdNotes
 
 		private static void SceneClosed(Scene scene)
 		{
+			if( cache == null ) return;
 			if (cache.ContainsKey(scene)) cache.Remove(scene);
 		}
 

--- a/Assets/EdNotes/Scripts/Editor/ShowEditorNoteInspector.cs
+++ b/Assets/EdNotes/Scripts/Editor/ShowEditorNoteInspector.cs
@@ -1,0 +1,43 @@
+﻿#if UNITY_EDITOR
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using EdNotes;
+using UnityEditor;
+
+[CustomEditor(typeof(ShowEditorNote))]
+public class ShowEditorNoteInspector : Editor
+{
+	private void Awake()
+	{
+		// thanks to SisusCo...
+		// https://forum.unity.com/threads/modifying-component-inspector-headers-for-component-folders.504247/
+		
+		// Change our ShowEditorNote inspector headers to just show "Editor Note"
+		Type inspectorTitlesType = typeof(ObjectNames).GetNestedType("InspectorTitles", BindingFlags.Static | BindingFlags.NonPublic);
+		var inspectorTitlesField = inspectorTitlesType.GetField("s_InspectorTitles", BindingFlags.Static | BindingFlags.NonPublic);
+		var cache = (Dictionary<Type, string>)inspectorTitlesField.GetValue(null);
+		cache[typeof(ShowEditorNote)] = "Editor Note";
+	}
+
+	public override void OnInspectorGUI()
+	{
+		ShowEditorNote targetScript = (ShowEditorNote)target;
+		var instanceId = targetScript.gameObject.GetInstanceID();
+
+		NotesContainer c = EditorNotes.GetContainer(targetScript.gameObject.scene);
+		var inCache = c.Cache.ContainsKey(instanceId);
+		if( inCache )
+		{
+			c.Cache.TryGetValue(instanceId, out Note note);
+			EditorGUILayout.LabelField($"{note.text}", EditorStyles.whiteLargeLabel);
+		}
+		else
+			EditorGUILayout.LabelField($"No Note has been saved for this GameObject, use Window > Notes", EditorStyles.boldLabel);
+	}
+}
+
+
+
+#endif

--- a/Assets/EdNotes/Scripts/Editor/ShowEditorNoteInspector.cs
+++ b/Assets/EdNotes/Scripts/Editor/ShowEditorNoteInspector.cs
@@ -31,7 +31,7 @@ public class ShowEditorNoteInspector : Editor
 		if( inCache )
 		{
 			c.Cache.TryGetValue(instanceId, out Note note);
-			EditorGUILayout.LabelField($"{note.text}", EditorStyles.whiteLargeLabel);
+			EditorGUILayout.TextArea($"{note.text}", EditorStyles.whiteLargeLabel);
 		}
 		else
 			EditorGUILayout.LabelField($"No Note has been saved for this GameObject, use Window > Notes", EditorStyles.boldLabel);

--- a/Assets/EdNotes/Scripts/Editor/ShowEditorNoteInspector.cs.meta
+++ b/Assets/EdNotes/Scripts/Editor/ShowEditorNoteInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c1d500737c68e304e846d0c511b38b18
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EdNotes/Scripts/ShowEditorNote.cs
+++ b/Assets/EdNotes/Scripts/ShowEditorNote.cs
@@ -1,0 +1,5 @@
+using UnityEngine;
+
+public class ShowEditorNote : MonoBehaviour
+{
+}

--- a/Assets/EdNotes/Scripts/ShowEditorNote.cs.meta
+++ b/Assets/EdNotes/Scripts/ShowEditorNote.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e31692a69cbe364998b22a77ab117c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Unity Editor Notes
 
-A simple tool to add notes to GameObject in the Hierarchy or Objects in the Project panel. The notes data in the scene are kept in a hidden object tagged as `EditorOnly` so the data will not end up in your final builds. The data concerning project objects are kept in an asset next to the this tool's scripts by default.
+A simple tool to add notes to GameObject in the **Hierarchy** or Objects in the **Project** panel. The notes data in the scene are kept in a hidden object tagged as `EditorOnly` so the data will not end up in your final builds. The data concerning project objects are kept in an asset next to the this tool's scripts by default.
 
 Open the Note panel via menu: `Window > Notes`. Enter some text and press [Save].
 
@@ -15,6 +15,16 @@ Click on the gear icon to show the Editor Notes settings where you can change th
 ![screenshot](https://user-images.githubusercontent.com/837362/30640573-bb962954-9e03-11e7-88e9-1d03f2379195.png)
 
 
+
+## Display Note in Inspector
+
+To display the note in the Inspector pane when you click on a game object in the Hierarchy, Add Component of type `ShowEditorNote`.
+
+## Installation
+
+- Click on Code > Download Zip
+
+- Copy the folder : `Assets\EdNotes` to your `Assets` folder
 
 
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Click on the gear icon to show the Editor Notes settings where you can change th
 
 To display the note in the Inspector pane when you click on a game object in the Hierarchy, Add Component of type `ShowEditorNote`.
 
+![editor_screenshot](https://github.com/mhardy/EdNotes/assets/115857/3acffcce-3f9b-4781-8bd7-f5aad04f80f2)
+
+
 ## Installation
 
 - Click on Code > Download Zip


### PR DESCRIPTION
Created a custom inspector and simple type called ShowEditorNote that, when added to a game object, will show the note for that game object if one has been created.

Also updated the readme with this info, a screenshot & install notes